### PR TITLE
Fix #12: Update all screens to responsive layout

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -71,7 +71,12 @@
 
 ### Buttons
 - **Never full width** — buttons should be sized to their content or capped with a max-width
-- **Primary action button**: max-width 340px, centered
+- **Primary action button**: max-width 340px, `alignSelf: 'center'`, `width: '100%'`
+
+### Quiz card
+- **Width**: `Math.min(screenWidth - 40, 640px)` — full width on phone, capped on desktop
+- **Height**: 45% of screen height
+- Uses `useWindowDimensions` (not static `Dimensions`) so it responds to window size
 
 ### Learn mode (quiz)
 - **Fullscreen** — no nav bar, no sidebar, distraction-free

--- a/screens/CreateDeckScreen.js
+++ b/screens/CreateDeckScreen.js
@@ -8,6 +8,8 @@ import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import Papa from 'papaparse';
 
+const MAX_CONTENT_WIDTH = 680;
+
 export default function CreateDeckScreen({ navigation }) {
   const [deckName, setDeckName] = useState('');
   const [cards, setCards] = useState([{ front: '', back: '' }]);
@@ -70,61 +72,65 @@ export default function CreateDeckScreen({ navigation }) {
   };
 
   return (
-    <ScrollView style={styles.container} keyboardShouldPersistTaps="handled">
-      <Text style={styles.label}>Deck Name</Text>
-      <TextInput
-        style={styles.input}
-        placeholder="e.g. Spanish Vocabulary"
-        value={deckName}
-        onChangeText={setDeckName}
-      />
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.contentContainer} keyboardShouldPersistTaps="handled">
+      <View style={styles.inner}>
+        <Text style={styles.label}>Deck Name</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="e.g. Spanish Vocabulary"
+          value={deckName}
+          onChangeText={setDeckName}
+        />
 
-      <TouchableOpacity style={styles.csvButton} onPress={importCSV} disabled={loading}>
-        {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.csvButtonText}>Import from CSV</Text>}
-      </TouchableOpacity>
-      <Text style={styles.csvHint}>CSV format: column 1 = front, column 2 = back</Text>
+        <TouchableOpacity style={styles.csvButton} onPress={importCSV} disabled={loading}>
+          {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.csvButtonText}>Import from CSV</Text>}
+        </TouchableOpacity>
+        <Text style={styles.csvHint}>CSV format: column 1 = front, column 2 = back</Text>
 
-      <Text style={styles.label}>Cards</Text>
-      {cards.map((card, index) => (
-        <View key={index} style={styles.cardRow}>
-          <View style={styles.cardInputs}>
-            <TextInput
-              style={styles.cardInput}
-              placeholder="Front (question)"
-              value={card.front}
-              onChangeText={v => updateCard(index, 'front', v)}
-              multiline
-              maxLength={1000}
-            />
-            <TextInput
-              style={styles.cardInput}
-              placeholder="Back (answer)"
-              value={card.back}
-              onChangeText={v => updateCard(index, 'back', v)}
-              multiline
-              maxLength={1000}
-            />
+        <Text style={styles.label}>Cards</Text>
+        {cards.map((card, index) => (
+          <View key={index} style={styles.cardRow}>
+            <View style={styles.cardInputs}>
+              <TextInput
+                style={styles.cardInput}
+                placeholder="Front (question)"
+                value={card.front}
+                onChangeText={v => updateCard(index, 'front', v)}
+                multiline
+                maxLength={1000}
+              />
+              <TextInput
+                style={styles.cardInput}
+                placeholder="Back (answer)"
+                value={card.back}
+                onChangeText={v => updateCard(index, 'back', v)}
+                multiline
+                maxLength={1000}
+              />
+            </View>
+            <TouchableOpacity onPress={() => removeCard(index)} style={styles.removeBtn}>
+              <Text style={styles.removeText}>✕</Text>
+            </TouchableOpacity>
           </View>
-          <TouchableOpacity onPress={() => removeCard(index)} style={styles.removeBtn}>
-            <Text style={styles.removeText}>✕</Text>
-          </TouchableOpacity>
-        </View>
-      ))}
+        ))}
 
-      <TouchableOpacity style={styles.addCardBtn} onPress={addCard}>
-        <Text style={styles.addCardText}>+ Add Card</Text>
-      </TouchableOpacity>
+        <TouchableOpacity style={styles.addCardBtn} onPress={addCard}>
+          <Text style={styles.addCardText}>+ Add Card</Text>
+        </TouchableOpacity>
 
-      <TouchableOpacity style={styles.saveButton} onPress={saveDeck}>
-        <Text style={styles.saveButtonText}>Save Deck</Text>
-      </TouchableOpacity>
-      <View style={{ height: 40 }} />
+        <TouchableOpacity style={styles.saveButton} onPress={saveDeck}>
+          <Text style={styles.saveButtonText}>Save deck</Text>
+        </TouchableOpacity>
+        <View style={{ height: 40 }} />
+      </View>
     </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20, backgroundColor: '#f5f5f5' },
+  scroll: { flex: 1, backgroundColor: '#f5f5f5' },
+  contentContainer: { alignItems: 'center' },
+  inner: { width: '100%', maxWidth: MAX_CONTENT_WIDTH, padding: 20 },
   label: { fontSize: 16, fontWeight: '600', marginTop: 16, marginBottom: 6 },
   input: {
     backgroundColor: '#fff', borderRadius: 8, padding: 12,
@@ -133,6 +139,7 @@ const styles = StyleSheet.create({
   csvButton: {
     backgroundColor: '#5a9e6f', padding: 12, borderRadius: 8,
     alignItems: 'center', marginTop: 16,
+    maxWidth: 340, alignSelf: 'center', width: '100%',
   },
   csvButtonText: { color: '#fff', fontSize: 15, fontWeight: '600' },
   csvHint: { color: '#999', fontSize: 12, marginTop: 4, marginBottom: 8 },
@@ -147,10 +154,12 @@ const styles = StyleSheet.create({
   addCardBtn: {
     borderWidth: 1, borderColor: '#4a90e2', borderRadius: 8,
     padding: 10, alignItems: 'center', marginBottom: 16,
+    maxWidth: 340, alignSelf: 'center', width: '100%',
   },
   addCardText: { color: '#4a90e2', fontSize: 15, fontWeight: '600' },
   saveButton: {
     backgroundColor: '#4a90e2', padding: 16, borderRadius: 12, alignItems: 'center',
+    maxWidth: 340, alignSelf: 'center', width: '100%',
   },
   saveButtonText: { color: '#fff', fontSize: 18, fontWeight: '600' },
 });

--- a/screens/EditDeckScreen.js
+++ b/screens/EditDeckScreen.js
@@ -1,19 +1,20 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
+import ScreenContainer from '../components/ScreenContainer';
 
 export default function EditDeckScreen({ route }) {
   const { deck } = route.params;
 
   return (
-    <View style={styles.container}>
+    <ScreenContainer style={styles.centered}>
       <Text style={styles.title}>Edit "{deck.name}"</Text>
       <Text style={styles.subtitle}>Coming soon</Text>
-    </View>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#f5f5f5' },
+  centered: { alignItems: 'center', justifyContent: 'center' },
   title: { fontSize: 22, fontWeight: '600', marginBottom: 12 },
   subtitle: { fontSize: 16, color: '#999' },
 });

--- a/screens/EndScreen.js
+++ b/screens/EndScreen.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import ScreenContainer from '../components/ScreenContainer';
 
 export default function EndScreen({ route, navigation }) {
   const { deckName, total } = route.params;
 
   return (
-    <View style={styles.container}>
+    <ScreenContainer style={styles.centered}>
       <Text style={styles.emoji}>🎉</Text>
-      <Text style={styles.title}>Deck Complete!</Text>
+      <Text style={styles.title}>Deck complete!</Text>
       <Text style={styles.subtitle}>You went through all {total} cards in</Text>
       <Text style={styles.deckName}>"{deckName}"</Text>
 
@@ -15,16 +16,16 @@ export default function EndScreen({ route, navigation }) {
         style={styles.button}
         onPress={() => navigation.navigate('Home')}
       >
-        <Text style={styles.buttonText}>Back to Decks</Text>
+        <Text style={styles.buttonText}>Back to decks</Text>
       </TouchableOpacity>
-    </View>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1, backgroundColor: '#f5f5f5',
-    alignItems: 'center', justifyContent: 'center', padding: 30,
+  centered: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   emoji: { fontSize: 64, marginBottom: 16 },
   title: { fontSize: 32, fontWeight: 'bold', marginBottom: 12 },

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -5,6 +5,7 @@ import {
 import { useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import SidebarLayout from '../components/SidebarLayout';
+import ScreenContainer from '../components/ScreenContainer';
 import { useBreakpoint } from '../hooks/useBreakpoint';
 
 export default function HomeScreen({ navigation }) {
@@ -26,7 +27,6 @@ export default function HomeScreen({ navigation }) {
 
   useFocusEffect(useCallback(() => { loadDecks(); }, []));
 
-  // Add hamburger button to nav bar on phone
   useEffect(() => {
     navigation.setOptions({
       headerLeft: isPhone ? () => (
@@ -100,7 +100,7 @@ export default function HomeScreen({ navigation }) {
       sidebarOpen={sidebarOpen}
       onClose={() => setSidebarOpen(false)}
     >
-      <View style={styles.container}>
+      <ScreenContainer>
         <Text style={styles.title}>My decks</Text>
 
         {decks.length === 0 ? (
@@ -156,13 +156,12 @@ export default function HomeScreen({ navigation }) {
         >
           <Text style={styles.createButtonText}>+ New deck</Text>
         </TouchableOpacity>
-      </View>
+      </ScreenContainer>
     </SidebarLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20, backgroundColor: '#f5f5f5' },
   title: { fontSize: 28, fontWeight: 'bold', marginBottom: 20, marginTop: 10, textAlign: 'center' },
   empty: { color: '#999', fontSize: 16, textAlign: 'center', marginTop: 60 },
   deckCard: {
@@ -179,6 +178,7 @@ const styles = StyleSheet.create({
   createButton: {
     backgroundColor: '#4a90e2', padding: 16, borderRadius: 12,
     alignItems: 'center', marginTop: 20,
+    maxWidth: 340, alignSelf: 'center', width: '100%',
   },
   createButtonText: { color: '#fff', fontSize: 18, fontWeight: '600' },
   modalOverlay: {


### PR DESCRIPTION
## Summary
- **HomeScreen**: wraps content in `ScreenContainer` (centered, max 680px on desktop); New deck button capped at 340px
- **CreateDeckScreen**: content centered with max 680px via ScrollView inner wrapper; CSV, Add Card, Save Deck buttons all capped at 340px
- **QuizScreen**: switched from static `Dimensions` to `useWindowDimensions`; card capped at 640px wide on desktop, full-width on phone; font measurement `textWidth` tracks actual card width
- **EndScreen**: wrapped in `ScreenContainer`; copy casing fixed
- **EditDeckScreen**: wrapped in `ScreenContainer`

## Test plan
- [ ] **Desktop/web**: Home — deck list and button are centered and don't stretch edge-to-edge in content area
- [ ] **Desktop/web**: New Deck — form and buttons are centered, not full-width
- [ ] **Desktop/web**: Quiz — card is capped in width, not stretching the full browser
- [ ] **iOS**: all screens look identical to before (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)