### PR TITLE
HomeScreen: fix menu, smart sort, empty state, UX polish

### DIFF
--- a/__mocks__/@expo/vector-icons.js
+++ b/__mocks__/@expo/vector-icons.js
@@ -1,0 +1,4 @@
+const React = require('react');
+const { View } = require('react-native');
+const Ionicons = () => React.createElement(View, { testID: 'ionicon' });
+module.exports = { Ionicons };

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,0 +1,376 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import HomeScreen from '../screens/HomeScreen';
+
+jest.setTimeout(15000);
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb) => {
+    const { useEffect } = require('react');
+    useEffect(cb, []);
+  },
+}));
+
+jest.mock('../components/SidebarLayout', () => {
+  const { View } = require('react-native');
+  return ({ children }) => <View>{children}</View>;
+});
+
+jest.mock('../components/ScreenContainer', () => {
+  const { View } = require('react-native');
+  return ({ children }) => <View>{children}</View>;
+});
+
+// Default: desktop layout
+const mockBreakpoint = { isPhone: false, isTablet: false, isDesktop: true };
+jest.mock('../hooks/useBreakpoint', () => ({
+  useBreakpoint: () => mockBreakpoint,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeNavigation() {
+  return { navigate: jest.fn(), setOptions: jest.fn() };
+}
+
+const DECK_A = {
+  id: '1',
+  name: 'Alpha',
+  cards: [{ front: 'Q1', back: 'A1' }],
+  isNew: false,
+  createdAt: 1000,
+  lastAccessedAt: 5000,
+};
+
+const DECK_B = {
+  id: '2',
+  name: 'Beta',
+  cards: [{ front: 'Q2', back: 'A2' }, { front: 'Q3', back: 'A3' }],
+  isNew: false,
+  createdAt: 2000,
+  lastAccessedAt: 3000,
+};
+
+const DECK_NEW = {
+  id: '3',
+  name: 'Zeta',
+  cards: [{ front: 'Q4', back: 'A4' }],
+  isNew: true,
+  createdAt: Date.now(),
+  lastAccessedAt: 1000,
+};
+
+async function renderWithDecks(decks, navigation) {
+  await AsyncStorage.setItem('decks', JSON.stringify(decks));
+  const nav = navigation ?? makeNavigation();
+  const utils = render(<HomeScreen navigation={nav} />);
+  // Wait for loadDecks to complete
+  await waitFor(() => expect(utils.getByText(decks[0].name)).toBeTruthy());
+  return { ...utils, nav };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AsyncStorage.clear();
+});
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('rendering', () => {
+  it('shows Decks heading', async () => {
+    const { getByText } = await renderWithDecks([DECK_A]);
+    expect(getByText('Decks')).toBeTruthy();
+  });
+
+  it('renders each deck name', async () => {
+    const { getByText } = await renderWithDecks([DECK_A, DECK_B]);
+    expect(getByText('Alpha')).toBeTruthy();
+    expect(getByText('Beta')).toBeTruthy();
+  });
+
+  it('shows card count for each deck', async () => {
+    const { getByText } = await renderWithDecks([DECK_A, DECK_B]);
+    expect(getByText('1 cards')).toBeTruthy();
+    expect(getByText('2 cards')).toBeTruthy();
+  });
+
+  it('shows New badge on new decks', async () => {
+    const { getByText } = await renderWithDecks([DECK_NEW]);
+    expect(getByText('New')).toBeTruthy();
+  });
+
+  it('does not show New badge on non-new decks', async () => {
+    const { queryByText } = await renderWithDecks([DECK_A]);
+    expect(queryByText('New')).toBeNull();
+  });
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe('empty state', () => {
+  it('shows empty state heading when no decks', async () => {
+    render(<HomeScreen navigation={makeNavigation()} />);
+    await waitFor(() => {
+      // loadDecks resolves with nothing, so empty state shows
+    });
+    const { getByText } = render(<HomeScreen navigation={makeNavigation()} />);
+    await waitFor(() => expect(getByText('No decks yet')).toBeTruthy());
+  });
+
+  it('shows CTA button in empty state', async () => {
+    const { getByText } = render(<HomeScreen navigation={makeNavigation()} />);
+    await waitFor(() => expect(getByText('+ Create your first deck')).toBeTruthy());
+  });
+
+  it('CTA navigates to NewDeck', async () => {
+    const nav = makeNavigation();
+    const { getByText } = render(<HomeScreen navigation={nav} />);
+    await waitFor(() => expect(getByText('+ Create your first deck')).toBeTruthy());
+    fireEvent.press(getByText('+ Create your first deck'));
+    expect(nav.navigate).toHaveBeenCalledWith('NewDeck');
+  });
+});
+
+// ── Auto-expire New badge ─────────────────────────────────────────────────────
+
+describe('auto-expire New badge', () => {
+  it('strips isNew when deck was created more than 7 days ago', async () => {
+    const oldNewDeck = {
+      ...DECK_NEW,
+      id: '99',
+      createdAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+    };
+    const { queryByText } = await renderWithDecks([oldNewDeck]);
+    expect(queryByText('New')).toBeNull();
+  });
+});
+
+// ── Sort control ──────────────────────────────────────────────────────────────
+
+describe('sort control', () => {
+  it('is not shown when there is only one deck', async () => {
+    const { queryByText } = await renderWithDecks([DECK_A]);
+    expect(queryByText('Recent')).toBeNull();
+    expect(queryByText('A–Z')).toBeNull();
+  });
+
+  it('is shown when there are two or more decks', async () => {
+    const { getByText } = await renderWithDecks([DECK_A, DECK_B]);
+    expect(getByText('Recent')).toBeTruthy();
+    expect(getByText('A–Z')).toBeTruthy();
+  });
+
+  it('defaults to Recent sort — new-badged deck appears first', async () => {
+    // DECK_NEW has isNew:true but low lastAccessedAt; should still sort first
+    const decks = [DECK_A, DECK_NEW];
+    await AsyncStorage.setItem('decks', JSON.stringify(decks));
+    const nav = makeNavigation();
+    const { getAllByText } = render(<HomeScreen navigation={nav} />);
+    await waitFor(() => getAllByText(/Alpha|Zeta/));
+    const names = getAllByText(/Alpha|Zeta/).map(n => n.props.children);
+    expect(names[0]).toBe('Zeta'); // new deck first
+  });
+
+  it('A-Z sort orders alphabetically', async () => {
+    // Beta created more recently so would be first in Recent; in A-Z Alpha should lead
+    const decks = [DECK_B, DECK_A]; // B stored first
+    await AsyncStorage.setItem('decks', JSON.stringify(decks));
+    const { getByText, getAllByText } = render(<HomeScreen navigation={makeNavigation()} />);
+    await waitFor(() => getByText('Beta'));
+    fireEvent.press(getByText('A–Z'));
+    const names = getAllByText(/Alpha|Beta/).map(n => n.props.children);
+    expect(names[0]).toBe('Alpha');
+  });
+
+  it('switching back to Recent after A-Z restores recency order', async () => {
+    // DECK_A has higher lastAccessedAt (5000) so should be first in Recent
+    const decks = [DECK_B, DECK_A];
+    await AsyncStorage.setItem('decks', JSON.stringify(decks));
+    const { getByText, getAllByText } = render(<HomeScreen navigation={makeNavigation()} />);
+    await waitFor(() => getByText('Beta'));
+    fireEvent.press(getByText('A–Z'));
+    fireEvent.press(getByText('Recent'));
+    const names = getAllByText(/Alpha|Beta/).map(n => n.props.children);
+    expect(names[0]).toBe('Alpha'); // lastAccessedAt 5000 > 3000
+  });
+});
+
+// ── Context menu ─────────────────────────────────────────────────────────────
+
+describe('context menu (desktop popup)', () => {
+  it('opens when ••• is pressed', async () => {
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => expect(getByText('Study')).toBeTruthy());
+  });
+
+  it('shows deck name as menu title', async () => {
+    const { getAllByText, getAllByText: getAll } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => {
+      const alphas = getAll('Alpha');
+      // One in the list, one in the menu title
+      expect(alphas.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('Study navigates to ModeSelect', async () => {
+    const nav = makeNavigation();
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A], nav);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Study'));
+    fireEvent.press(getByText('Study'));
+    expect(nav.navigate).toHaveBeenCalledWith('ModeSelect', expect.objectContaining({ deck: expect.objectContaining({ id: '1' }) }));
+  });
+
+  it('Edit cards navigates to EditDeck', async () => {
+    const nav = makeNavigation();
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A], nav);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Edit cards'));
+    fireEvent.press(getByText('Edit cards'));
+    expect(nav.navigate).toHaveBeenCalledWith('EditDeck', { deck: expect.objectContaining({ id: '1' }) });
+  });
+
+  it('Rename opens the rename modal', async () => {
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Rename'));
+    fireEvent.press(getByText('Rename'));
+    await waitFor(() => expect(getByText('Rename deck')).toBeTruthy());
+  });
+
+  it('Delete opens the delete confirmation modal', async () => {
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Delete'));
+    fireEvent.press(getByText('Delete'));
+    await waitFor(() => expect(getByText('Delete deck?')).toBeTruthy());
+  });
+});
+
+// ── Rename flow ───────────────────────────────────────────────────────────────
+
+describe('rename flow', () => {
+  it('saves updated name to AsyncStorage', async () => {
+    const { getAllByText, getByText, getByDisplayValue } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Rename'));
+    fireEvent.press(getByText('Rename'));
+    await waitFor(() => getByText('Rename deck'));
+    fireEvent.changeText(getByDisplayValue('Alpha'), 'Alpha Renamed');
+    fireEvent.press(getByText('Save'));
+    await waitFor(() => {
+      const calls = AsyncStorage.setItem.mock.calls;
+      const lastSave = JSON.parse(calls[calls.length - 1][1]);
+      expect(lastSave[0].name).toBe('Alpha Renamed');
+    });
+  });
+
+  it('Cancel closes rename modal without saving', async () => {
+    const { getAllByText, getByText, getByDisplayValue, queryByText } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Rename'));
+    fireEvent.press(getByText('Rename'));
+    await waitFor(() => getByText('Rename deck'));
+    fireEvent.changeText(getByDisplayValue('Alpha'), 'Should Not Save');
+    fireEvent.press(getByText('Cancel'));
+    await waitFor(() => expect(queryByText('Rename deck')).toBeNull());
+    expect(getByText('Alpha')).toBeTruthy();
+  });
+});
+
+// ── Delete flow ───────────────────────────────────────────────────────────────
+
+describe('delete flow', () => {
+  it('removes deck from list on confirm', async () => {
+    const { getAllByText, getByText, queryByText } = await renderWithDecks([DECK_A, DECK_B]);
+    // Open menu for Alpha (first ••• button)
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Delete'));
+    fireEvent.press(getByText('Delete'));
+    await waitFor(() => getByText('Delete deck?'));
+    fireEvent.press(getByText('Delete'));
+    await waitFor(() => expect(queryByText('Alpha')).toBeNull());
+    expect(getByText('Beta')).toBeTruthy();
+  });
+
+  it('Cancel leaves deck intact', async () => {
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Delete'));
+    fireEvent.press(getByText('Delete'));
+    await waitFor(() => getByText('Delete deck?'));
+    fireEvent.press(getByText('Cancel'));
+    await waitFor(() => expect(getByText('Alpha')).toBeTruthy());
+  });
+
+  it('persists deletion to AsyncStorage', async () => {
+    const { getAllByText, getByText } = await renderWithDecks([DECK_A, DECK_B]);
+    fireEvent.press(getAllByText('•••')[0]);
+    await waitFor(() => getByText('Delete'));
+    fireEvent.press(getByText('Delete'));
+    await waitFor(() => getByText('Delete deck?'));
+    fireEvent.press(getByText('Delete'));
+    await waitFor(() => {
+      const calls = AsyncStorage.setItem.mock.calls;
+      const lastSave = JSON.parse(calls[calls.length - 1][1]);
+      expect(lastSave.every(d => d.id !== '1')).toBe(true);
+    });
+  });
+});
+
+// ── openDeck ──────────────────────────────────────────────────────────────────
+
+describe('opening a deck', () => {
+  it('navigates to ModeSelect', async () => {
+    const nav = makeNavigation();
+    const { getByText } = await renderWithDecks([DECK_A], nav);
+    fireEvent.press(getByText('Alpha'));
+    expect(nav.navigate).toHaveBeenCalledWith('ModeSelect', expect.objectContaining({
+      deck: expect.objectContaining({ id: '1' }),
+    }));
+  });
+
+  it('clears isNew flag on open', async () => {
+    const nav = makeNavigation();
+    const { getByText } = await renderWithDecks([DECK_NEW], nav);
+    fireEvent.press(getByText('Zeta'));
+    await waitFor(() => {
+      const calls = AsyncStorage.setItem.mock.calls;
+      const lastSave = JSON.parse(calls[calls.length - 1][1]);
+      expect(lastSave[0].isNew).toBe(false);
+    });
+  });
+
+  it('stamps lastAccessedAt on open', async () => {
+    const before = Date.now();
+    const nav = makeNavigation();
+    const { getByText } = await renderWithDecks([DECK_A], nav);
+    fireEvent.press(getByText('Alpha'));
+    await waitFor(() => {
+      const calls = AsyncStorage.setItem.mock.calls;
+      const lastSave = JSON.parse(calls[calls.length - 1][1]);
+      expect(lastSave[0].lastAccessedAt).toBeGreaterThanOrEqual(before);
+    });
+  });
+});
+
+// ── New deck button ───────────────────────────────────────────────────────────
+
+describe('new deck button', () => {
+  it('is shown on desktop when decks exist', async () => {
+    const { getByText } = await renderWithDecks([DECK_A]);
+    expect(getByText('+ New deck')).toBeTruthy();
+  });
+
+  it('navigates to NewDeck when pressed', async () => {
+    const nav = makeNavigation();
+    const { getByText } = await renderWithDecks([DECK_A], nav);
+    fireEvent.press(getByText('+ New deck'));
+    expect(nav.navigate).toHaveBeenCalledWith('NewDeck');
+  });
+});

--- a/__tests__/UploadScreen.test.js
+++ b/__tests__/UploadScreen.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+jest.setTimeout(15000);
 import { Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as DocumentPicker from 'expo-document-picker';
@@ -110,7 +112,7 @@ describe('UploadScreen', () => {
       });
     });
 
-    it('derives deck name from filename (strips extension)', async () => {
+    it('converts hyphenated filename to Title Case deck name', async () => {
       mockSuccessfulPick('european-capitals.csv');
       mockParsedCards([['Spain', 'Madrid']]);
 
@@ -119,7 +121,33 @@ describe('UploadScreen', () => {
 
       await waitFor(() => {
         const saved = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
-        expect(saved[0].name).toBe('european-capitals');
+        expect(saved[0].name).toBe('European Capitals');
+      });
+    });
+
+    it('converts underscored filename to Title Case deck name', async () => {
+      mockSuccessfulPick('spanish_nouns.csv');
+      mockParsedCards([['el libro', 'book']]);
+
+      const { getByText } = render(<UploadScreen navigation={makeNavigation()} />);
+      fireEvent.press(getByText('Choose file'));
+
+      await waitFor(() => {
+        const saved = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
+        expect(saved[0].name).toBe('Spanish Nouns');
+      });
+    });
+
+    it('handles filename with no separators', async () => {
+      mockSuccessfulPick('vocabulary.csv');
+      mockParsedCards([['word', 'definition']]);
+
+      const { getByText } = render(<UploadScreen navigation={makeNavigation()} />);
+      fireEvent.press(getByText('Choose file'));
+
+      await waitFor(() => {
+        const saved = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
+        expect(saved[0].name).toBe('Vocabulary');
       });
     });
 

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -12,19 +12,14 @@ export default function Sidebar({ navigation, onClose }) {
   return (
     <View style={styles.container}>
 
-      <View style={styles.section}>
-        <Text style={styles.sectionLabel}>MY DECKS</Text>
-        <TouchableOpacity style={styles.item} onPress={() => navigate('Home')}>
-          <Ionicons name="albums-outline" size={18} color={colors.brand} style={styles.itemIcon} />
-          <Text style={styles.itemText}>My decks</Text>
-        </TouchableOpacity>
-      </View>
+      <TouchableOpacity style={styles.item} onPress={() => navigate('Home')}>
+        <Ionicons name="albums-outline" size={18} color={colors.brand} style={styles.itemIcon} />
+        <Text style={styles.itemText}>My decks</Text>
+      </TouchableOpacity>
 
-      <View style={styles.divider} />
-
-      <TouchableOpacity style={styles.newDeckBtn} onPress={() => navigate('NewDeck')}>
+      <TouchableOpacity style={styles.item} onPress={() => navigate('NewDeck')}>
         <Ionicons name="add-circle-outline" size={18} color={colors.brand} style={styles.itemIcon} />
-        <Text style={styles.newDeckText}>New deck</Text>
+        <Text style={styles.itemText}>New deck</Text>
       </TouchableOpacity>
 
     </View>
@@ -37,21 +32,10 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surface,
     paddingTop: 20,
   },
-  section: {
-    paddingHorizontal: 16,
-    marginBottom: 8,
-  },
-  sectionLabel: {
-    fontSize: 10,
-    fontWeight: '700',
-    color: colors.textMuted,
-    letterSpacing: 1.2,
-    marginBottom: 6,
-    paddingHorizontal: 6,
-  },
   item: {
     flexDirection: 'row',
     alignItems: 'center',
+    marginHorizontal: 8,
     paddingHorizontal: 10,
     paddingVertical: 10,
     borderRadius: radius.sm,
@@ -63,24 +47,5 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
     color: colors.textPrimary,
-  },
-  divider: {
-    height: 1,
-    backgroundColor: colors.borderLight,
-    marginHorizontal: 16,
-    marginVertical: 8,
-  },
-  newDeckBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginHorizontal: 16,
-    paddingHorizontal: 10,
-    paddingVertical: 10,
-    borderRadius: radius.sm,
-  },
-  newDeckText: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.brand,
   },
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "jest": {
     "preset": "jest-expo",
     "moduleNameMapper": {
-      "@react-native-async-storage/async-storage": "@react-native-async-storage/async-storage/jest/async-storage-mock"
+      "@react-native-async-storage/async-storage": "@react-native-async-storage/async-storage/jest/async-storage-mock",
+      "@expo/vector-icons": "<rootDir>/__mocks__/@expo/vector-icons.js"
     }
   },
   "dependencies": {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import {
-  View, Text, FlatList, TouchableOpacity, StyleSheet, Alert, ActionSheetIOS, TextInput, Modal
+  View, Text, FlatList, TouchableOpacity, StyleSheet, TextInput, Modal, Platform,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -8,19 +8,28 @@ import { Ionicons } from '@expo/vector-icons';
 import SidebarLayout from '../components/SidebarLayout';
 import ScreenContainer from '../components/ScreenContainer';
 import { useBreakpoint } from '../hooks/useBreakpoint';
-
 import { colors, shadows, radius } from '../constants/theme';
 
 const TROPHY_COLORS = colors.trophy;
-
 const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
 
 export default function HomeScreen({ navigation }) {
   const [decks, setDecks] = useState([]);
+  const [sortAlpha, setSortAlpha] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Deck action sheet
+  const [menuDeck, setMenuDeck] = useState(null);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  // Rename modal
   const [renameVisible, setRenameVisible] = useState(false);
   const [renameDeckId, setRenameDeckId] = useState(null);
   const [renameText, setRenameText] = useState('');
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Delete confirm modal
+  const [deleteDeck, setDeleteDeck] = useState(null);
+
   const { isPhone } = useBreakpoint();
 
   const loadDecks = async () => {
@@ -29,8 +38,6 @@ export default function HomeScreen({ navigation }) {
       if (!stored) return;
       const parsed = JSON.parse(stored);
       const now = Date.now();
-
-      // Auto-expire New badge after 7 days
       const updated = parsed.map(d =>
         d.isNew && d.createdAt && now - d.createdAt > SEVEN_DAYS
           ? { ...d, isNew: false }
@@ -50,7 +57,7 @@ export default function HomeScreen({ navigation }) {
     navigation.setOptions({
       headerLeft: isPhone ? () => (
         <TouchableOpacity onPress={() => setSidebarOpen(true)} style={styles.hamburgerBtn}>
-          <Ionicons name="menu" size={26} color="#fff" />
+          <Ionicons name="menu" size={26} color={colors.surface} />
         </TouchableOpacity>
       ) : () => null,
     });
@@ -61,28 +68,20 @@ export default function HomeScreen({ navigation }) {
     await AsyncStorage.setItem('decks', JSON.stringify(updated));
   };
 
-  const clearNewBadge = (deck) => {
-    if (!deck.isNew) return;
-    const updated = decks.map(d => d.id === deck.id ? { ...d, isNew: false } : d);
+  // Opens a deck: clears new badge + stamps lastAccessedAt in one write
+  const openDeck = (deck) => {
+    const now = Date.now();
+    const updated = decks.map(d =>
+      d.id === deck.id ? { ...d, isNew: false, lastAccessedAt: now } : d
+    );
     saveDecks(updated);
+    navigation.navigate('ModeSelect', { deck: { ...deck, isNew: false, lastAccessedAt: now } });
   };
 
-  const deleteDeck = (deck) => {
-    Alert.alert(
-      `Delete "${deck.name}"`,
-      'Are you sure?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete', style: 'destructive', onPress: async () => {
-            await saveDecks(decks.filter(d => d.id !== deck.id));
-          }
-        }
-      ]
-    );
-  };
+  const closeMenu = () => setMenuVisible(false);
 
   const startRename = (deck) => {
+    closeMenu();
     setRenameDeckId(deck.id);
     setRenameText(deck.name);
     setRenameVisible(true);
@@ -97,22 +96,43 @@ export default function HomeScreen({ navigation }) {
     setRenameVisible(false);
   };
 
-  const showMenu = (deck) => {
-    ActionSheetIOS.showActionSheetWithOptions(
-      {
-        title: deck.name,
-        options: ['Cancel', 'Learn', 'Rename', 'Edit', 'Delete'],
-        cancelButtonIndex: 0,
-        destructiveButtonIndex: 4,
-      },
-      (index) => {
-        if (index === 1) { clearNewBadge(deck); navigation.navigate('ModeSelect', { deck }); }
-        if (index === 2) startRename(deck);
-        if (index === 3) navigation.navigate('EditDeck', { deck });
-        if (index === 4) deleteDeck(deck);
-      }
-    );
+  const confirmDelete = async () => {
+    await saveDecks(decks.filter(d => d.id !== deleteDeck.id));
+    setDeleteDeck(null);
   };
+
+  // Sort: new-badged first → lastAccessedAt desc → createdAt desc; or A–Z
+  const sortedDecks = [...decks].sort((a, b) => {
+    if (sortAlpha) return a.name.localeCompare(b.name);
+    if (a.isNew !== b.isNew) return a.isNew ? -1 : 1;
+    const aTime = a.lastAccessedAt || a.createdAt || 0;
+    const bTime = b.lastAccessedAt || b.createdAt || 0;
+    return bTime - aTime;
+  });
+
+  const menuActions = menuDeck ? [
+    {
+      label: 'Study',
+      icon: 'play-circle-outline',
+      onPress: () => { closeMenu(); openDeck(menuDeck); },
+    },
+    {
+      label: 'Rename',
+      icon: 'pencil-outline',
+      onPress: () => startRename(menuDeck),
+    },
+    {
+      label: 'Edit cards',
+      icon: 'create-outline',
+      onPress: () => { closeMenu(); navigation.navigate('EditDeck', { deck: menuDeck }); },
+    },
+    {
+      label: 'Delete',
+      icon: 'trash-outline',
+      danger: true,
+      onPress: () => { closeMenu(); setDeleteDeck(menuDeck); },
+    },
+  ] : [];
 
   return (
     <SidebarLayout
@@ -120,89 +140,220 @@ export default function HomeScreen({ navigation }) {
       sidebarOpen={sidebarOpen}
       onClose={() => setSidebarOpen(false)}
     >
-      <ScreenContainer>
-        <Text style={styles.title}>My decks</Text>
+      <View style={{ flex: 1 }}>
+        <ScreenContainer>
 
-        {decks.length === 0 ? (
-          <Text style={styles.empty}>No decks yet. Create one!</Text>
-        ) : (
-          <FlatList
-            data={decks}
-            keyExtractor={item => item.id}
-            renderItem={({ item }) => (
-              <View style={styles.deckCard}>
-                {/* Accent strip */}
-                <View style={styles.deckAccent} />
-                <TouchableOpacity
-                  style={styles.deckInfo}
-                  onPress={() => { clearNewBadge(item); navigation.navigate('ModeSelect', { deck: item }); }}
-                >
-                  <Text style={styles.deckName} numberOfLines={1}>{item.name}</Text>
-                  <View style={styles.deckMeta}>
-                    <Text style={styles.deckCount}>{item.cards.length} cards</Text>
-                    {item.isNew && (
-                      <View style={styles.newBadge}>
-                        <Text style={styles.newBadgeText}>New</Text>
-                      </View>
-                    )}
-                    {/* Earned trophies */}
-                    {['bronze', 'silver', 'gold'].some(t => item.trophies?.[t]) && (
-                      <View style={styles.trophyMini}>
-                        {['bronze', 'silver', 'gold'].map(tier =>
-                          item.trophies?.[tier] ? (
-                            <Ionicons key={tier} name="trophy" size={14} color={TROPHY_COLORS[tier]} />
-                          ) : null
-                        )}
-                      </View>
-                    )}
-                  </View>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-                <TouchableOpacity style={styles.menuBtn} onPress={() => showMenu(item)}>
-                  <Text style={styles.menuDots}>•••</Text>
-                </TouchableOpacity>
-              </View>
+          {/* Header row */}
+          <View style={styles.headerRow}>
+            <Text style={styles.title}>Decks</Text>
+            {decks.length > 1 && (
+              <TouchableOpacity
+                style={styles.sortBtn}
+                onPress={() => setSortAlpha(v => !v)}
+              >
+                <Ionicons name="swap-vertical-outline" size={14} color={colors.brand} />
+                <Text style={styles.sortBtnText}>{sortAlpha ? 'Recent' : 'A–Z'}</Text>
+              </TouchableOpacity>
             )}
-          />
-        )}
+          </View>
 
-        {/* Rename modal */}
-        <Modal visible={renameVisible} transparent animationType="fade">
-          <View style={styles.modalOverlay}>
-            <View style={styles.modalBox}>
-              <Text style={styles.modalTitle}>Rename deck</Text>
-              <TextInput
-                style={styles.modalInput}
-                value={renameText}
-                onChangeText={setRenameText}
-                autoFocus
-              />
-              <View style={styles.modalButtons}>
-                <TouchableOpacity onPress={() => setRenameVisible(false)} style={styles.modalCancel}>
-                  <Text style={styles.modalCancelText}>Cancel</Text>
-                </TouchableOpacity>
-                <TouchableOpacity onPress={confirmRename} style={styles.modalSave}>
-                  <Text style={styles.modalSaveText}>Save</Text>
-                </TouchableOpacity>
-              </View>
+          {decks.length === 0 ? (
+            <EmptyState onPress={() => navigation.navigate('NewDeck')} />
+          ) : (
+            <FlatList
+              data={sortedDecks}
+              keyExtractor={item => item.id}
+              contentContainerStyle={isPhone ? { paddingBottom: 88 } : undefined}
+              renderItem={({ item }) => (
+                <View style={styles.deckCard}>
+                  <View style={styles.deckAccent} />
+                  <TouchableOpacity
+                    style={styles.deckInfo}
+                    onPress={() => openDeck(item)}
+                  >
+                    <Text style={styles.deckName} numberOfLines={1}>{item.name}</Text>
+                    <View style={styles.deckMeta}>
+                      <Text style={styles.deckCount}>{item.cards.length} cards</Text>
+                      {item.isNew && (
+                        <View style={styles.newBadge}>
+                          <Text style={styles.newBadgeText}>New</Text>
+                        </View>
+                      )}
+                      {['bronze', 'silver', 'gold'].some(t => item.trophies?.[t]) && (
+                        <View style={styles.trophyMini}>
+                          {['bronze', 'silver', 'gold'].map(tier =>
+                            item.trophies?.[tier]
+                              ? <Ionicons key={tier} name="trophy" size={14} color={TROPHY_COLORS[tier]} />
+                              : null
+                          )}
+                        </View>
+                      )}
+                    </View>
+                  </TouchableOpacity>
+                  <View style={styles.divider} />
+                  <TouchableOpacity
+                    style={styles.menuBtn}
+                    onPress={() => { setMenuDeck(item); setMenuVisible(true); }}
+                  >
+                    <Text style={styles.menuDots}>•••</Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+            />
+          )}
+
+          {/* New deck button — desktop only (mobile has sticky footer) */}
+          {!isPhone && decks.length > 0 && (
+            <TouchableOpacity
+              style={styles.createButton}
+              onPress={() => navigation.navigate('NewDeck')}
+            >
+              <Text style={styles.createButtonText}>+ New deck</Text>
+            </TouchableOpacity>
+          )}
+
+        </ScreenContainer>
+
+        {/* Sticky footer — mobile only */}
+        {isPhone && (
+          <View style={styles.stickyFooter}>
+            <TouchableOpacity
+              style={styles.createButton}
+              onPress={() => navigation.navigate('NewDeck')}
+            >
+              <Text style={styles.createButtonText}>+ New deck</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
+      {/* ── Deck action sheet ── */}
+      <Modal visible={menuVisible} transparent animationType="fade">
+        <TouchableOpacity
+          style={styles.menuOverlay}
+          onPress={closeMenu}
+          activeOpacity={1}
+        >
+          <View style={styles.menuSheet}>
+            <Text style={styles.menuSheetTitle} numberOfLines={1}>
+              {menuDeck?.name}
+            </Text>
+            {menuActions.map(({ label, icon, danger, onPress }) => (
+              <TouchableOpacity key={label} style={styles.menuRow} onPress={onPress}>
+                <Ionicons
+                  name={icon}
+                  size={20}
+                  color={danger ? colors.danger : colors.textPrimary}
+                  style={styles.menuRowIcon}
+                />
+                <Text style={[styles.menuRowText, danger && styles.menuRowTextDanger]}>
+                  {label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+            <TouchableOpacity style={styles.menuCancelRow} onPress={closeMenu}>
+              <Text style={styles.menuCancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+      </Modal>
+
+      {/* ── Rename modal ── */}
+      <Modal visible={renameVisible} transparent animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalBox}>
+            <Text style={styles.modalTitle}>Rename deck</Text>
+            <TextInput
+              style={styles.modalInput}
+              value={renameText}
+              onChangeText={setRenameText}
+              autoFocus
+              onSubmitEditing={confirmRename}
+            />
+            <View style={styles.modalButtons}>
+              <TouchableOpacity onPress={() => setRenameVisible(false)} style={styles.modalCancel}>
+                <Text style={styles.modalCancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={confirmRename} style={styles.modalSave}>
+                <Text style={styles.modalSaveText}>Save</Text>
+              </TouchableOpacity>
             </View>
           </View>
-        </Modal>
+        </View>
+      </Modal>
 
-        <TouchableOpacity
-          style={styles.createButton}
-          onPress={() => navigation.navigate('NewDeck')}
-        >
-          <Text style={styles.createButtonText}>+ New deck</Text>
-        </TouchableOpacity>
-      </ScreenContainer>
+      {/* ── Delete confirm modal ── */}
+      <Modal visible={!!deleteDeck} transparent animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalBox}>
+            <Text style={styles.modalTitle}>Delete deck?</Text>
+            <Text style={styles.modalMessage}>
+              "{deleteDeck?.name}" will be permanently deleted.
+            </Text>
+            <View style={styles.modalButtons}>
+              <TouchableOpacity onPress={() => setDeleteDeck(null)} style={styles.modalCancel}>
+                <Text style={styles.modalCancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={confirmDelete} style={styles.modalDelete}>
+                <Text style={styles.modalDeleteText}>Delete</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
     </SidebarLayout>
   );
 }
 
+function EmptyState({ onPress }) {
+  return (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyIcon}>📚</Text>
+      <Text style={styles.emptyHeading}>No decks yet</Text>
+      <Text style={styles.emptySubtext}>
+        Create your first deck and start learning. You can type cards manually or import a spreadsheet.
+      </Text>
+      <TouchableOpacity style={styles.emptyBtn} onPress={onPress}>
+        <Text style={styles.emptyBtnText}>+ Create your first deck</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
-  title: { fontSize: 26, fontWeight: '800', color: colors.textPrimary, marginBottom: 20, marginTop: 10, textAlign: 'center' },
-  empty: { color: colors.textSecondary, fontSize: 16, textAlign: 'center', marginTop: 60 },
+  hamburgerBtn: { paddingLeft: 12 },
+
+  // Header row
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 10,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: colors.textPrimary,
+  },
+  sortBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: colors.brand,
+  },
+  sortBtnText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.brand,
+  },
+
+  // Deck list
   deckCard: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -222,14 +373,18 @@ const styles = StyleSheet.create({
   deckMeta: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 4 },
   deckCount: { fontSize: 13, color: colors.textSecondary },
   newBadge: {
-    backgroundColor: colors.brand, borderRadius: radius.badge,
-    paddingHorizontal: 8, paddingVertical: 2,
+    backgroundColor: colors.brand,
+    borderRadius: radius.badge,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
   },
   newBadgeText: { color: colors.surface, fontSize: 11, fontWeight: '700', letterSpacing: 0.5 },
   trophyMini: { flexDirection: 'row', gap: 3, alignItems: 'center' },
   divider: { width: 1, height: '60%', backgroundColor: colors.border },
-  menuBtn: { paddingHorizontal: 10, paddingVertical: 16 },
+  menuBtn: { paddingHorizontal: 14, paddingVertical: 16 },
   menuDots: { fontSize: 14, color: colors.textSecondary, letterSpacing: 2 },
+
+  // New deck button (desktop inline + mobile sticky)
   createButton: {
     backgroundColor: colors.accent,
     padding: 16,
@@ -241,20 +396,124 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   createButtonText: { color: colors.textPrimary, fontSize: 17, fontWeight: '700' },
-  modalOverlay: {
-    flex: 1, backgroundColor: 'rgba(0,0,0,0.4)',
-    alignItems: 'center', justifyContent: 'center',
+
+  stickyFooter: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: colors.background,
+    paddingHorizontal: 20,
+    paddingTop: 10,
+    paddingBottom: 16,
+    borderTopWidth: 1,
+    borderTopColor: colors.borderLight,
   },
-  modalBox: { backgroundColor: colors.surface, borderRadius: radius.md, padding: 24, width: '80%' },
-  modalTitle: { fontSize: 18, fontWeight: '600', marginBottom: 12 },
+
+  // Empty state
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 60,
+  },
+  emptyIcon: { fontSize: 56, marginBottom: 16 },
+  emptyHeading: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: colors.textPrimary,
+    marginBottom: 10,
+  },
+  emptySubtext: {
+    fontSize: 15,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 32,
+    maxWidth: 300,
+  },
+  emptyBtn: {
+    backgroundColor: colors.accent,
+    paddingHorizontal: 28,
+    paddingVertical: 14,
+    borderRadius: radius.md,
+  },
+  emptyBtnText: { color: colors.textPrimary, fontSize: 16, fontWeight: '700' },
+
+  // Deck action sheet
+  menuOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  menuSheet: {
+    backgroundColor: colors.surface,
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    paddingBottom: 32,
+    paddingTop: 8,
+    ...shadows.overlay,
+  },
+  menuSheetTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderLight,
+    marginBottom: 4,
+  },
+  menuRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 14,
+  },
+  menuRowIcon: { marginRight: 14 },
+  menuRowText: { fontSize: 17, color: colors.textPrimary },
+  menuRowTextDanger: { color: colors.danger },
+  menuCancelRow: {
+    marginTop: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+    borderTopWidth: 1,
+    borderTopColor: colors.borderLight,
+  },
+  menuCancelText: { fontSize: 17, color: colors.textSecondary, fontWeight: '500' },
+
+  // Rename / delete modals
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modalBox: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.md,
+    padding: 24,
+    width: '80%',
+    maxWidth: 360,
+  },
+  modalTitle: { fontSize: 18, fontWeight: '600', marginBottom: 8, color: colors.textPrimary },
+  modalMessage: { fontSize: 14, color: colors.textSecondary, marginBottom: 20, lineHeight: 20 },
   modalInput: {
-    borderWidth: 1, borderColor: colors.border, borderRadius: radius.sm,
-    padding: 10, fontSize: 16, marginBottom: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.sm,
+    padding: 10,
+    fontSize: 16,
+    marginBottom: 16,
+    color: colors.textPrimary,
   },
   modalButtons: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12 },
   modalCancel: { padding: 8 },
   modalCancelText: { fontSize: 16, color: colors.textSecondary },
   modalSave: { padding: 8 },
   modalSaveText: { fontSize: 16, color: colors.brand, fontWeight: '600' },
-  hamburgerBtn: { paddingLeft: 12 },
+  modalDelete: { padding: 8 },
+  modalDeleteText: { fontSize: 16, color: colors.danger, fontWeight: '600' },
 });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import {
-  View, Text, FlatList, TouchableOpacity, StyleSheet, TextInput, Modal, Platform,
+  View, Text, FlatList, TouchableOpacity, StyleSheet, TextInput, Modal,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -18,16 +18,13 @@ export default function HomeScreen({ navigation }) {
   const [sortAlpha, setSortAlpha] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // Deck action sheet
   const [menuDeck, setMenuDeck] = useState(null);
   const [menuVisible, setMenuVisible] = useState(false);
 
-  // Rename modal
   const [renameVisible, setRenameVisible] = useState(false);
   const [renameDeckId, setRenameDeckId] = useState(null);
   const [renameText, setRenameText] = useState('');
 
-  // Delete confirm modal
   const [deleteDeck, setDeleteDeck] = useState(null);
 
   const { isPhone } = useBreakpoint();
@@ -68,7 +65,6 @@ export default function HomeScreen({ navigation }) {
     await AsyncStorage.setItem('decks', JSON.stringify(updated));
   };
 
-  // Opens a deck: clears new badge + stamps lastAccessedAt in one write
   const openDeck = (deck) => {
     const now = Date.now();
     const updated = decks.map(d =>
@@ -101,7 +97,6 @@ export default function HomeScreen({ navigation }) {
     setDeleteDeck(null);
   };
 
-  // Sort: new-badged first → lastAccessedAt desc → createdAt desc; or A–Z
   const sortedDecks = [...decks].sort((a, b) => {
     if (sortAlpha) return a.name.localeCompare(b.name);
     if (a.isNew !== b.isNew) return a.isNew ? -1 : 1;
@@ -147,13 +142,24 @@ export default function HomeScreen({ navigation }) {
           <View style={styles.headerRow}>
             <Text style={styles.title}>Decks</Text>
             {decks.length > 1 && (
-              <TouchableOpacity
-                style={styles.sortBtn}
-                onPress={() => setSortAlpha(v => !v)}
-              >
-                <Ionicons name="swap-vertical-outline" size={14} color={colors.brand} />
-                <Text style={styles.sortBtnText}>{sortAlpha ? 'Recent' : 'A–Z'}</Text>
-              </TouchableOpacity>
+              <View style={styles.segControl}>
+                <TouchableOpacity
+                  style={[styles.segBtn, !sortAlpha && styles.segBtnActive]}
+                  onPress={() => setSortAlpha(false)}
+                >
+                  <Text style={[styles.segBtnText, !sortAlpha && styles.segBtnTextActive]}>
+                    Recent
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.segBtn, sortAlpha && styles.segBtnActive]}
+                  onPress={() => setSortAlpha(true)}
+                >
+                  <Text style={[styles.segBtnText, sortAlpha && styles.segBtnTextActive]}>
+                    A–Z
+                  </Text>
+                </TouchableOpacity>
+              </View>
             )}
           </View>
 
@@ -167,10 +173,7 @@ export default function HomeScreen({ navigation }) {
               renderItem={({ item }) => (
                 <View style={styles.deckCard}>
                   <View style={styles.deckAccent} />
-                  <TouchableOpacity
-                    style={styles.deckInfo}
-                    onPress={() => openDeck(item)}
-                  >
+                  <TouchableOpacity style={styles.deckInfo} onPress={() => openDeck(item)}>
                     <Text style={styles.deckName} numberOfLines={1}>{item.name}</Text>
                     <View style={styles.deckMeta}>
                       <Text style={styles.deckCount}>{item.cards.length} cards</Text>
@@ -202,7 +205,6 @@ export default function HomeScreen({ navigation }) {
             />
           )}
 
-          {/* New deck button — desktop only (mobile has sticky footer) */}
           {!isPhone && decks.length > 0 && (
             <TouchableOpacity
               style={styles.createButton}
@@ -214,7 +216,6 @@ export default function HomeScreen({ navigation }) {
 
         </ScreenContainer>
 
-        {/* Sticky footer — mobile only */}
         {isPhone && (
           <View style={styles.stickyFooter}>
             <TouchableOpacity
@@ -227,35 +228,52 @@ export default function HomeScreen({ navigation }) {
         )}
       </View>
 
-      {/* ── Deck action sheet ── */}
+      {/* ── Deck action menu ── */}
       <Modal visible={menuVisible} transparent animationType="fade">
-        <TouchableOpacity
-          style={styles.menuOverlay}
-          onPress={closeMenu}
-          activeOpacity={1}
-        >
-          <View style={styles.menuSheet}>
-            <Text style={styles.menuSheetTitle} numberOfLines={1}>
-              {menuDeck?.name}
-            </Text>
-            {menuActions.map(({ label, icon, danger, onPress }) => (
-              <TouchableOpacity key={label} style={styles.menuRow} onPress={onPress}>
-                <Ionicons
-                  name={icon}
-                  size={20}
-                  color={danger ? colors.danger : colors.textPrimary}
-                  style={styles.menuRowIcon}
-                />
-                <Text style={[styles.menuRowText, danger && styles.menuRowTextDanger]}>
-                  {label}
-                </Text>
+        {isPhone ? (
+          // Mobile: compact bottom sheet
+          <TouchableOpacity style={styles.sheetOverlay} onPress={closeMenu} activeOpacity={1}>
+            <View style={styles.sheet}>
+              <Text style={styles.sheetTitle} numberOfLines={1}>{menuDeck?.name}</Text>
+              {menuActions.map(({ label, icon, danger, onPress }) => (
+                <TouchableOpacity key={label} style={styles.sheetRow} onPress={onPress}>
+                  <Ionicons
+                    name={icon}
+                    size={18}
+                    color={danger ? colors.danger : colors.textPrimary}
+                    style={styles.sheetRowIcon}
+                  />
+                  <Text style={[styles.sheetRowText, danger && styles.sheetRowTextDanger]}>
+                    {label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+              <TouchableOpacity style={styles.sheetCancel} onPress={closeMenu}>
+                <Text style={styles.sheetCancelText}>Cancel</Text>
               </TouchableOpacity>
-            ))}
-            <TouchableOpacity style={styles.menuCancelRow} onPress={closeMenu}>
-              <Text style={styles.menuCancelText}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
-        </TouchableOpacity>
+            </View>
+          </TouchableOpacity>
+        ) : (
+          // Desktop: small centered popup
+          <TouchableOpacity style={styles.popupOverlay} onPress={closeMenu} activeOpacity={1}>
+            <View style={styles.popup}>
+              <Text style={styles.popupTitle} numberOfLines={1}>{menuDeck?.name}</Text>
+              {menuActions.map(({ label, icon, danger, onPress }) => (
+                <TouchableOpacity key={label} style={styles.popupRow} onPress={onPress}>
+                  <Ionicons
+                    name={icon}
+                    size={16}
+                    color={danger ? colors.danger : colors.textPrimary}
+                    style={styles.popupRowIcon}
+                  />
+                  <Text style={[styles.popupRowText, danger && styles.popupRowTextDanger]}>
+                    {label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </TouchableOpacity>
+        )}
       </Modal>
 
       {/* ── Rename modal ── */}
@@ -294,8 +312,8 @@ export default function HomeScreen({ navigation }) {
               <TouchableOpacity onPress={() => setDeleteDeck(null)} style={styles.modalCancel}>
                 <Text style={styles.modalCancelText}>Cancel</Text>
               </TouchableOpacity>
-              <TouchableOpacity onPress={confirmDelete} style={styles.modalDelete}>
-                <Text style={styles.modalDeleteText}>Delete</Text>
+              <TouchableOpacity onPress={confirmDelete} style={styles.modalSave}>
+                <Text style={[styles.modalSaveText, { color: colors.danger }]}>Delete</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -337,20 +355,29 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     color: colors.textPrimary,
   },
-  sortBtn: {
+
+  // Segmented sort control
+  segControl: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: 10,
+    backgroundColor: colors.borderLight,
+    borderRadius: radius.pill,
+    padding: 3,
+  },
+  segBtn: {
+    paddingHorizontal: 12,
     paddingVertical: 5,
     borderRadius: radius.pill,
-    borderWidth: 1,
-    borderColor: colors.brand,
   },
-  sortBtnText: {
+  segBtnActive: {
+    backgroundColor: colors.brand,
+  },
+  segBtnText: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.brand,
+    color: colors.textSecondary,
+  },
+  segBtnTextActive: {
+    color: colors.surface,
   },
 
   // Deck list
@@ -384,7 +411,7 @@ const styles = StyleSheet.create({
   menuBtn: { paddingHorizontal: 14, paddingVertical: 16 },
   menuDots: { fontSize: 14, color: colors.textSecondary, letterSpacing: 2 },
 
-  // New deck button (desktop inline + mobile sticky)
+  // New deck button
   createButton: {
     backgroundColor: colors.accent,
     padding: 16,
@@ -441,50 +468,82 @@ const styles = StyleSheet.create({
   },
   emptyBtnText: { color: colors.textPrimary, fontSize: 16, fontWeight: '700' },
 
-  // Deck action sheet
-  menuOverlay: {
+  // Mobile bottom sheet
+  sheetOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
+    backgroundColor: 'rgba(0,0,0,0.35)',
     justifyContent: 'flex-end',
   },
-  menuSheet: {
+  sheet: {
     backgroundColor: colors.surface,
     borderTopLeftRadius: radius.lg,
     borderTopRightRadius: radius.lg,
-    paddingBottom: 32,
-    paddingTop: 8,
-    ...shadows.overlay,
+    paddingBottom: 24,
+    paddingTop: 4,
   },
-  menuSheetTitle: {
-    fontSize: 13,
+  sheetTitle: {
+    fontSize: 12,
     fontWeight: '600',
     color: colors.textMuted,
     textAlign: 'center',
-    paddingVertical: 12,
+    paddingVertical: 10,
     paddingHorizontal: 20,
     borderBottomWidth: 1,
     borderBottomColor: colors.borderLight,
-    marginBottom: 4,
+    marginBottom: 2,
   },
-  menuRow: {
+  sheetRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 24,
-    paddingVertical: 14,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
   },
-  menuRowIcon: { marginRight: 14 },
-  menuRowText: { fontSize: 17, color: colors.textPrimary },
-  menuRowTextDanger: { color: colors.danger },
-  menuCancelRow: {
-    marginTop: 8,
-    paddingVertical: 14,
+  sheetRowIcon: { marginRight: 12 },
+  sheetRowText: { fontSize: 15, color: colors.textPrimary },
+  sheetRowTextDanger: { color: colors.danger },
+  sheetCancel: {
+    marginTop: 6,
+    paddingVertical: 12,
     alignItems: 'center',
     borderTopWidth: 1,
     borderTopColor: colors.borderLight,
   },
-  menuCancelText: { fontSize: 17, color: colors.textSecondary, fontWeight: '500' },
+  sheetCancelText: { fontSize: 15, color: colors.textSecondary },
 
-  // Rename / delete modals
+  // Desktop popup menu
+  popupOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  popup: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.md,
+    width: 200,
+    paddingVertical: 6,
+    ...shadows.lg,
+  },
+  popupTitle: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.textMuted,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderLight,
+  },
+  popupRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  popupRowIcon: { marginRight: 10 },
+  popupRowText: { fontSize: 14, color: colors.textPrimary },
+  popupRowTextDanger: { color: colors.danger },
+
+  // Shared modals
   modalOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0,0,0,0.4)',
@@ -514,6 +573,4 @@ const styles = StyleSheet.create({
   modalCancelText: { fontSize: 16, color: colors.textSecondary },
   modalSave: { padding: 8 },
   modalSaveText: { fontSize: 16, color: colors.brand, fontWeight: '600' },
-  modalDelete: { padding: 8 },
-  modalDeleteText: { fontSize: 16, color: colors.danger, fontWeight: '600' },
 });

--- a/screens/UploadScreen.js
+++ b/screens/UploadScreen.js
@@ -22,7 +22,11 @@ const SPREADSHEET_TYPES = [
 ];
 
 function deriveNameFromFilename(filename) {
-  return filename.replace(/\.[^/.]+$/, '').trim();
+  return filename
+    .replace(/\.[^/.]+$/, '')        // strip extension
+    .replace(/[-_]+/g, ' ')          // hyphens/underscores → spaces
+    .replace(/\b\w/g, c => c.toUpperCase())  // title case
+    .trim();
 }
 
 export default function UploadScreen({ navigation }) {


### PR DESCRIPTION
## Summary
- **Fix broken ellipsis menu on web** — replaced `ActionSheetIOS` with a cross-platform bottom sheet modal; `Alert.alert` for delete also replaced with a custom modal
- **Smart sort order** — New-badged decks float to top; remaining sorted by last-accessed (most recent first); `lastAccessedAt` stamped on every deck open; A–Z toggle appears when >1 deck
- **Instructive empty state** — replaces the bare "No decks yet" string with icon, heading, subtext, and a CTA button
- **Reduce "My decks" repetition** — page heading replaced with compact "Decks" label in a functional header row with sort toggle
- **New deck button placement** — sticky footer on mobile; inline below list on desktop (sidebar nav already provides the link)
- **Fix imported deck names** — `european-capitals` now imports as `European Capitals`

## Test plan
- [ ] Ellipsis menu opens and all four actions work (Study, Rename, Edit, Delete) on web and mobile
- [ ] Delete shows confirmation modal; Cancel aborts, Delete removes the deck
- [ ] Rename updates deck name inline
- [ ] Opening a deck stamps `lastAccessedAt`; re-ordering is correct on return to home
- [ ] A–Z toggle sorts alphabetically; Recent toggle restores recency order
- [ ] Empty state renders with working CTA when no decks exist
- [ ] Import a CSV named `my-deck.csv` — verify it appears as `My Deck`
- [ ] Mobile: New deck button sticks to bottom and doesn't obscure the last list item

🤖 Generated with [Claude Code](https://claude.com/claude-code)